### PR TITLE
ci: disable automatic triggers on all workflows (manual dispatch only)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,10 +1,7 @@
 name: Build and Test
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,10 +1,7 @@
 name: Docker Build and Scan
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-complete-suite.yml
+++ b/.github/workflows/e2e-complete-suite.yml
@@ -1,10 +1,7 @@
 name: e2e-complete-suite
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/governance-resilience-periodic.yml
+++ b/.github/workflows/governance-resilience-periodic.yml
@@ -1,8 +1,6 @@
 name: governance-resilience-periodic
 
 on:
-  schedule:
-    - cron: '17 2 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,13 +1,7 @@
 name: Security Scanning
 
 on:
-  push:
-    branches: [ main, develop ]
-  pull_request:
-    branches: [ main, develop ]
-  schedule:
-    # Run weekly on Mondays at 00:00 UTC
-    - cron: '0 0 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -1,10 +1,6 @@
 name: SLSA Provenance
 
 on:
-  push:
-    branches: [ main ]
-    tags:
-      - 'v*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Replace push/pull_request/tag/schedule triggers with workflow_dispatch across all 7 GitHub Actions workflows so none run automatically on any branch. Pipelines remain launchable manually from the Actions tab.